### PR TITLE
Add Timber as logging framework

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,6 +48,8 @@ staticCodeAnalysis {
 dependencies {
     compile 'com.android.support:appcompat-v7:24.0.0'
 
+    compile 'com.jakewharton.timber:timber:4.1.2'
+
     androidLint 'com.monits:android-linters:1.1.9'
 
     def stethoVersion = '1.3.1'

--- a/app/src/debug/java/com/ksss/splintter/DebugApplication.java
+++ b/app/src/debug/java/com/ksss/splintter/DebugApplication.java
@@ -7,6 +7,8 @@ import com.facebook.stetho.Stetho;
 import com.nshmura.strictmodenotifier.StrictModeNotifier;
 import com.squareup.leakcanary.LeakCanary;
 
+import timber.log.Timber;
+
 /**
  * Created by Nahuel Barrios on 7/16/16.
  */
@@ -14,7 +16,11 @@ public class DebugApplication extends MainApplication {
 
     @Override
     public void onCreate() {
+        Timber.plant(new Timber.DebugTree());
+
         super.onCreate();
+
+        Timber.d("Creating DEBUG application...");
 
         Stetho.initializeWithDefaults(this);
         LeakCanary.install(this);

--- a/app/src/main/java/com/ksss/splintter/MainApplication.java
+++ b/app/src/main/java/com/ksss/splintter/MainApplication.java
@@ -2,10 +2,17 @@ package com.ksss.splintter;
 
 import android.app.Application;
 
+import timber.log.Timber;
+
 /**
  * Created by Nahuel Barrios on 7/16/16.
  */
 
 public class MainApplication extends Application {
 
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        Timber.d("Creating MAIN application...");
+    }
 }


### PR DESCRIPTION
- closes #4 

It will only log for the debug variant.

Then we can encapsulate our bug tracking framework under a custom tree as seen at: https://github.com/JakeWharton/timber/blob/master/timber-sample/src/main/java/com/example/timber/ExampleApp.java
